### PR TITLE
Add missing tag to goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ dockers:
       - "ghcr.io/rode/collector-build:latest"
       - "ghcr.io/rode/collector-build:{{ .Tag }}"
       - "ghcr.io/rode/collector-build:v{{ .Major }}"
+      - "ghcr.io/rode/collector-build:v{{ .Major }}.{{ .Minor }}"
     extra_files:
       - "go.mod"
       - "go.sum"


### PR DESCRIPTION
This repo was used to generate the collector template, which I noticed was missing one of the tags we typically use on releases. I addressed that in https://github.com/rode/new-collector-template/pull/4 and this PR does the same thing here. 